### PR TITLE
fixing a problem with executables not copied into the bin folder

### DIFF
--- a/.github/workflows/compile-test-actions.yml
+++ b/.github/workflows/compile-test-actions.yml
@@ -17,13 +17,13 @@ jobs:
       - name: Setup docker images
         run: sudo bash ./ev3dev-cpp-template-wrapper/scripts/dockersetup.sh
       - name: compile the contents
-        run: sudo bash ./scripts/compile.sh
+        run: sudo bash ./scripts/compile.sh -w
   compile-inside-container:
     runs-on: ubuntu-latest
     env:
       GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
     container: 
-      image: ev3dev/debian-stretch-cross:latest
+      image: eisverygoodletter/debian-stretch-cross:latest
       options: --user root -e GIT_DISCOVERY_ACROSS_FILESYSTEM=1
     steps:
       - name: install git

--- a/.github/workflows/compile-test-actions.yml
+++ b/.github/workflows/compile-test-actions.yml
@@ -15,11 +15,11 @@ jobs:
           sudo apt-get install -y git
       - uses: actions/checkout@v3
         with: 
-          path: main
+          path: ./
       - uses: actions/checkout@v3
         with:
           repository: rshs-robotics-club/ev3dev-cpp-template-wrapper
-          path: ./
+          path: ./ev3dev-cpp-template-wrapper
       - name: compile it
         run: |
           sudo chmod +x ./scripts/runWithinContainer.sh

--- a/.github/workflows/compile-test-actions.yml
+++ b/.github/workflows/compile-test-actions.yml
@@ -1,23 +1,6 @@
 name: compile-test
 on: [pull_request]
 jobs:
-  compile-out-of-container:
-    runs-on: ubuntu-latest
-    steps:
-      #- name: install Docker
-      #  run: |
-      #    sudo apt-get update
-      #    sudo apt install snap
-      #    sudo snap install docker
-
-      - name: Download this repo
-        uses: actions/checkout@v3
-        with:
-          submodules: 'true'
-      - name: Setup docker images
-        run: sudo bash ./ev3dev-cpp-template-wrapper/scripts/dockersetup.sh
-      - name: compile the contents
-        run: sudo bash ./scripts/compile.sh -w
   compile-inside-container:
     runs-on: ubuntu-latest
     env:
@@ -36,10 +19,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: rshs-robotics-club/ev3dev-cpp-template-wrapper
-          path: main/ev3dev-cpp-template-wrapper
+          path: ./
       - name: compile it
         run: |
-          cd main
           sudo chmod +x ./scripts/runWithinContainer.sh
-          sudo bash ./scripts/runWithinContainer.sh
+          sudo bash ./scripts/runWithinContainer.sh -w
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,22 +33,7 @@ file(GLOB tempLinkFiles "./src/templinks/*.cpp")
 set(YOUR_PROJECT_FINISHED_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bin)
 foreach(file ${files})
     get_filename_component(fileName ${file} NAME_WE)
-    #target_include_directories(${fileName}_EXECUTABLE PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
     add_executable(${fileName}_EXECUTABLE ${file} ${tempLinkFiles})
-    # target_precompile_headers(${LIBNAME}
-#     PUBLIC
-#     lib/blockable/ev3wrapblockable.hpp
-#     lib/button/ev3wrapbutton.hpp
-#     lib/color/ev3wrapcolor.hpp
-#     lib/compass/ev3wrapcompass.hpp
-#     lib/irseeker/ev3wrapirseeker.hpp
-#     lib/motor/ev3wrapmotor.hpp
-#     lib/ultrasonic/ev3wrapultrasonic.hpp
-#     lib/utilities/ev3wraputilities.hpp
-#     lib/vector/ev3wrapvector.hpp
-#     lib/ev3dev.h
-#     lib/ev3wrap.hpp
-# )
     set(YOUR_PROJECT_FINISHED_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bin)
     target_link_libraries(${fileName}_EXECUTABLE ev3-cpp-template-wrapper-lib)
     
@@ -56,6 +41,11 @@ foreach(file ${files})
         ${fileName}_EXECUTABLE
         PROPERTIES
         OUTPUT_NAME ${fileName}.elf
+    )
+    add_custom_command(
+        TARGET ${fileName}_EXECUTABLE POST_BUILD
+        COMMAND sudo mkdir -p ${YOUR_PROJECT_FINISHED_DIR}
+        COMMAND sudo cp ${PROJECT_BINARY_DIR}/${fileName}.elf  ${YOUR_PROJECT_FINISHED_DIR}/${fileName}.elf
     )
     if (${VERBOSE}) 
         add_custom_target(
@@ -66,8 +56,6 @@ foreach(file ${files})
         add_dependencies(${fileName}_TARGET ${fileName}_EXECUTABLE)
         add_custom_command(
             TARGET ${fileName}_TARGET POST_BUILD
-            COMMAND sudo mkdir -p ${YOUR_PROJECT_FINISHED_DIR}
-            COMMAND sudo cp ${PROJECT_BINARY_DIR}/${fileName}.elf  ${YOUR_PROJECT_FINISHED_DIR}/${fileName}.elf
             COMMAND sudo bash ${CMAKE_CURRENT_SOURCE_DIR}/scripts/post_build.sh ${fileName}.elf 500 ${YOUR_PROJECT_FINISHED_DIR}/${fileName}.elf 50
         )
     endif()

--- a/scripts/runWithinContainer.sh
+++ b/scripts/runWithinContainer.sh
@@ -67,8 +67,9 @@ Commands used     : $@
 --------------------------------------------------------------------------------------
 "
 if [ $wipeBin = true ]; then
-    echo "Wiping bin folder"
+    echo "Wiping bin, build and CMakeFiles folder"
     sudo rm -rf build
+    sudo rm -rf bin
     sudo rm -rf CMakeFiles
 fi
 if [ $newFile = true ]; then
@@ -82,4 +83,4 @@ fi
 
 echo "building library starting with $(nproc) jobs"
 
-cmake --build build -j$(nproc)
+cmake --build build -j $(nproc)


### PR DESCRIPTION
fixed these [2 lines](https://github.com/rshs-robotics-club/ev3dev-cpp-wrapper-example/blob/2156848fb564bb7cec6e0a01013a78cd6eca3043/CMakeLists.txt#L69-L70) being inaccessible unless verbose mode is activated